### PR TITLE
Use explode_dn

### DIFF
--- a/src/node/ext/ldap/ugm/_api.py
+++ b/src/node/ext/ldap/ugm/_api.py
@@ -484,7 +484,7 @@ class LDAPPrincipals(OdictStorage):
             if prdn in self.context._deleted_children:
                 raise KeyError(key)
             dn = res[0][0]
-            path = explode_dn(dn)[:len(self.context.DN.split(',')) * -1]
+            path = explode_dn(dn.encode('utf-8'))[:len(self.context.DN.split(',')) * -1]
             context = self.context
             for rdn in reversed(path):
                 context = context[rdn]

--- a/src/node/ext/ldap/ugm/_api.py
+++ b/src/node/ext/ldap/ugm/_api.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from ldap.dn import explode_dn
 from node.behaviors import Adopt
 from node.behaviors import Alias
 from node.behaviors import Attributes
@@ -483,8 +484,7 @@ class LDAPPrincipals(OdictStorage):
             if prdn in self.context._deleted_children:
                 raise KeyError(key)
             dn = res[0][0]
-            # XXX: use explode_dn
-            path = dn.split(',')[:len(self.context.DN.split(',')) * -1]
+            path = explode_dn(dn)[:len(self.context.DN.split(',')) * -1]
             context = self.context
             for rdn in reversed(path):
                 context = context[rdn]


### PR DESCRIPTION
If the dn contains escaped commas, it fails. 
Using explode_cn fixes the bug. I think it is related to bug #26
e.g. dn=u'CN=Municio Garcia\\, Diego,OU=myou,DC=local'