### PR TITLE
Use ReconnectLDAPObject to make connection more robust. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ History
 1.0b8 (unreleased)
 ------------------
 
+- Use ``ldap.ldapobject.ReconnectLDAPObject`` instead of ``SimpleLDAPObject`` to create
+  the connection object. This makes the connection more robust.
+  Add properties `retry_max` (default 1) and `retry_delay` (default 10) to
+  ``node.ext.ldap.properties.LDAPServerProperties`` to configure ``ReconnectLDAPObject``.
+  [joka]
+
 - Use ``explode_dn`` in ``LDAPPrincipals.__getitem__`` to prevent ``KeyError``
   if DN contains comma.
   [dmunicio]

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Calling ``bind`` creates and returns the LDAP connection:
 .. code-block:: pycon
 
     >>> connector.bind()
-    <ldap.ldapobject.SimpleLDAPObject instance at ...>
+    <ldap.ldapobject.ReconnectLDAPObject instance at ...>
 
 Calling ``unbind`` destroys the connection:
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'python-ldap',
+        'python-ldap>=2.4.14',
         'smbpasswd',
         'argparse',
         'bda.cache',

--- a/src/node/ext/ldap/base.py
+++ b/src/node/ext/ldap/base.py
@@ -81,6 +81,8 @@ class LDAPConnector(object):
         self._start_tls = props.start_tls
         self._ignore_cert = props.ignore_cert
         self._tls_cacert_file = props.tls_cacertfile
+        self._retry_max = props.retry_max
+        self._retry_delay = props.retry_delay
 
     def bind(self):
         """Bind to Server and return the Connection Object.
@@ -89,7 +91,11 @@ class LDAPConnector(object):
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
         elif self._tls_cacert_file:
             ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self._tls_cacert_file)
-        self._con = ldap.initialize(self._uri)
+        self._con = ldap.ldapobject.ReconnectLDAPObject(
+            self._uri,
+            retry_max=self._retry_max,
+            retry_delay=self._retry_delay,
+        )
         # Turning referrals off since they cause problems with MS Active
         # Directory More info: https://www.python-ldap.org/faq.html#usage
         self._con.set_option(ldap.OPT_REFERRALS, 0)

--- a/src/node/ext/ldap/properties.py
+++ b/src/node/ext/ldap/properties.py
@@ -89,9 +89,8 @@ class LDAPServerProperties(object):
         :param tls_cacertdir: Not yet
         :param tls_clcertfile: Not yet
         :param tls_clkeyfile: Not yet
-        :param retry_max: Maximum count of reconnect trials. Not yet
+        :param retry_max: Maximum count of reconnect trials. Value has to be >= 1
         :param retry_delay: Time span to wait between two reconnect trials.
-            Not yet
         :param multivalued_attributes: Set of attributes names considered as
             multivalued to be returned as list.
         :param binary_attributes: Set of attributes names considered as binary.


### PR DESCRIPTION
Use ``ldap.ldapobject.ReconnectLDAPObject`` instead of
``SimpleLDAPObject`` to create the connection object.
  This makes the connection more robust.

Add properties `retry_max` (default 1) and `retry_delay` (default 10)
to ``node.ext.ldap.properties.LDAPServerProperties`` to configure
``ReconnectLDAPObject``.

 