### PR TITLE
Skip found LDAP objects that miss required attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ History
 1.0b11 (unreleased)
 -------------------
 
-- No changes yet.
+- Skip objects that were found in LDAP while searching on several attributes but don't contain the required attribute.
+  [fredvd, maurits]
 
 
 1.0b10 (2019-06-30)

--- a/src/node/ext/ldap/ugm/_api.py
+++ b/src/node/ext/ldap/ugm/_api.py
@@ -649,7 +649,10 @@ class LDAPPrincipals(OdictStorage):
         if attrlist is not None:
             _results = list()
             for _, att in results:
-                principal_id = att[self._key_attr][0]
+                try:
+                    principal_id = att[self._key_attr][0]
+                except (KeyError, IndexError):
+                    continue
                 aliased = self._alias_dict(att)
                 for key in list(aliased.keys()):
                     if key not in attrlist:


### PR DESCRIPTION
Skip objects that were found in LDAP while searching on several attributes but don't contain the required attribute. We see this on the sharing tab when searching for ('*van*').

(Somehow when this error occurs, the LDAP (or maybe memcache) does not find any users in future requests, until you restart the Zope instance, but that is a separate issue.)

Original fix by Fred, cherry-picked by Maurits.

This replaces PR #37. Not sure if there is anything left to do for that one.

cc @rnixx 