### PR TITLE
Return empty search result list when an LDAP error occurs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ History
 1.0b11 (unreleased)
 -------------------
 
+- Return empty search result list when an LDAP error occurs.
+  Fixes `issue #50 <https://github.com/bluedynamics/node.ext.ldap/issues/50>`_.
+  [maurits]
+
 - Skip objects that were found in LDAP while searching on several attributes but don't contain the required attribute.
   [fredvd, maurits]
 

--- a/src/node/ext/ldap/base.py
+++ b/src/node/ext/ldap/base.py
@@ -222,14 +222,18 @@ class LDAPCommunicator(object):
             # in case we do pagination of results
             if type(attrlist) in (list, tuple):
                 attrlist = [str(_) for _ in attrlist]
-            msgid = self._con.search_ext(
-                baseDN,
-                scope,
-                queryFilter,
-                attrlist,
-                attrsonly,
-                serverctrls=serverctrls
-            )
+            try:
+                msgid = self._con.search_ext(
+                    baseDN,
+                    scope,
+                    queryFilter,
+                    attrlist,
+                    attrsonly,
+                    serverctrls=serverctrls
+                )
+            except ldap.LDAPError as e:
+                logger.warn(str(e))
+                return []
             rtype, results, rmsgid, rctrls = self._con.result3(msgid)
             ctype = ldap.controls.libldap.SimplePagedResultsControl.controlType
             pctrls = [c for c in rctrls if c.controlType == ctype]


### PR DESCRIPTION
Fixes issue #50.